### PR TITLE
Add multi-GPU training support via accelerate launch

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,6 +133,11 @@ async def start_training(request: Request) -> JSONResponse:
     train_type = request.query_params.get("train_mode", "lora")
     is_flux = request.query_params.get("flux", "False") == "True"
     is_anima = request.query_params.get("anima", "False") == "True"
+
+    # Parse accelerate (multi-GPU) settings
+    accelerate_enabled = request.query_params.get("accelerate_enabled", "False") == "True"
+    accelerate_num_processes = int(request.query_params.get("accelerate_num_processes", "2"))
+    accelerate_main_process_port = int(request.query_params.get("accelerate_main_process_port", "29500"))
     match [train_type, is_sdxl, is_flux, is_anima]:
         case ["lora", False, False, False]:
             app.state.TRAIN_SCRIPT = "train_network.py"
@@ -169,14 +174,30 @@ async def start_training(request: Request) -> JSONResponse:
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     print(app.state.TRAIN_SCRIPT)
-    app.state.TRAINING_THREAD = subprocess.Popen(
-        [
-            f"{python}",
-            f"{Path(f'sd_scripts/{app.state.TRAIN_SCRIPT}').resolve()}",
+
+    # Build command based on accelerate settings
+    if accelerate_enabled:
+        # Multi-GPU training with accelerate launch
+        cmd = [
+            python,
+            "-m", "accelerate.commands.launch",
+            f"--num_processes={accelerate_num_processes}",
+            f"--main_process_port={accelerate_main_process_port}",
+            str(Path(f"sd_scripts/{app.state.TRAIN_SCRIPT}").resolve()),
             f"--config_file={config.resolve()}",
             f"--dataset_config={dataset.resolve()}",
         ]
-    )
+        print(f"Launching with accelerate: {accelerate_num_processes} processes")
+    else:
+        # Single GPU training (original behavior)
+        cmd = [
+            python,
+            str(Path(f"sd_scripts/{app.state.TRAIN_SCRIPT}").resolve()),
+            f"--config_file={config.resolve()}",
+            f"--dataset_config={dataset.resolve()}",
+        ]
+
+    app.state.TRAINING_THREAD = subprocess.Popen(cmd)
     if (
         "kill_tunnel_on_train_start" in server_config_dict
         and server_config_dict["kill_tunnel_on_train_start"]

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -61,10 +61,14 @@ def validate(args: dict) -> tuple[bool, bool, list[str], dict, dict]:
                 del args_data["run_name"]
         if "run_name_mode" in args_data: del args_data["run_name_mode"]
 
+    # Get num_processes from accelerate settings for multi-GPU step calculations
+    accelerate = args.get("accelerate", {})
+    num_processes = accelerate.get("num_processes", 1) if accelerate.get("enabled", False) else 1
+
     tag_data = {}
     if not over_errors:
-        validate_warmup_ratio(args_data, dataset_data)
-        validate_restarts(args_data, dataset_data)
+        validate_warmup_ratio(args_data, dataset_data, num_processes)
+        validate_restarts(args_data, dataset_data, num_processes)
         tag_data = validate_save_tags(dataset_data)
         validate_existing_files(args_data)
         validate_optimizer(args_data)
@@ -255,7 +259,7 @@ def validate_subset(args: dict) -> tuple[bool, list[str], dict]:
     return passed_validation, errors, output_args
 
 
-def validate_restarts(args: dict, dataset: dict) -> None:
+def validate_restarts(args: dict, dataset: dict, num_processes: int = 1) -> None:
     if "lr_scheduler_num_cycles" not in args:
         return
     if "lr_scheduler_type" not in args:
@@ -267,13 +271,14 @@ def validate_restarts(args: dict, dataset: dict) -> None:
             dataset,
             args["max_train_epochs"],
             args.get("gradient_accumulation_steps", 1),
+            num_processes,
         )
     steps = steps // args["lr_scheduler_num_cycles"]
     args["lr_scheduler_args"].append(f"first_cycle_max_steps={steps}")
     #del args["lr_scheduler_num_cycles"]
 
 
-def validate_warmup_ratio(args: dict, dataset: dict) -> None:
+def validate_warmup_ratio(args: dict, dataset: dict, num_processes: int = 1) -> None:
     if "warmup_ratio" not in args:
         return
     if "max_train_steps" in args:
@@ -283,6 +288,7 @@ def validate_warmup_ratio(args: dict, dataset: dict) -> None:
             dataset,
             args["max_train_epochs"],
             args.get("gradient_accumulation_steps", 1),
+            num_processes,
         )
     steps = round(steps * args["warmup_ratio"])
     if "lr_scheduler_type" in args:
@@ -354,6 +360,7 @@ def calculate_steps(
     dataset_args: dict[str, dict | list[dict]],
     num_epochs: int,
     grad_acc_steps: int = 1,
+    num_processes: int = 1,
 ) -> int:
     general_args: dict = dataset_args["general"]
     subsets: list = dataset_args["subsets"]
@@ -390,4 +397,4 @@ def calculate_steps(
     steps_before_acc = sum(
         math.ceil(len(bucket) / general_args["batch_size"]) for bucket in bucketManager.buckets
     )
-    return math.ceil(steps_before_acc / grad_acc_steps) * num_epochs
+    return math.ceil(steps_before_acc / grad_acc_steps / num_processes) * num_epochs


### PR DESCRIPTION
Adds accelerate launch integration for distributed multi-GPU training:
- Parse accelerate settings (enabled, num_processes, main_process_port) from request params
- Build accelerate launch command when enabled, preserving original single-GPU behavior as default
- Account for num_processes when calculating training steps for warmup ratio and scheduler restarts